### PR TITLE
Ensure the second element of `err` is an Exception

### DIFF
--- a/nosehtml/plugin.py
+++ b/nosehtml/plugin.py
@@ -102,17 +102,23 @@ class NoseHTML(Plugin):
         """
         self.print_test('success', test)
 
-    def addFailure(self, test, error):
+    def addFailure(self, test, err):
         """
         Test failed
         """
-        self.print_test('failure', test, '\n'.join(traceback.format_exception(*error)))
+        err_type, err_value, err_traceback = err
+        if not isinstance(err_value, Exception):
+            err_value = Exception(err_value)
+        self.print_test('failure', test, '\n'.join(traceback.format_exception(err_type, err_value, err_traceback)))
 
-    def addError(self, test, error):
+    def addError(self, test, err):
         """
         Test errored.
         """
-        self.print_test('error', test, '\n'.join(traceback.format_exception(*error)))
+        err_type, err_value, err_traceback = err
+        if not isinstance(err_value, Exception):
+            err_value = Exception(err_value)
+        self.print_test('error', test, '\n'.join(traceback.format_exception(err_type, err_value, err_traceback)))
 
     def addDeprecated(self, test):
         """


### PR DESCRIPTION
Fix the following traceback on Python 3.4:
```
Traceback (most recent call last):
  File "/usr/users/ga002/soranzon/software/nsoranzo_galaxy/.tox/py34-unit/lib/python3.4/site-packages/nose/case.py", line 134, in run
    self.runTest(result)
  File "/usr/users/ga002/soranzon/software/nsoranzo_galaxy/.tox/py34-unit/lib/python3.4/site-packages/nose/case.py", line 152, in runTest
    test(result)
  File "/usr/lib/python3.4/unittest/case.py", line 628, in __call__
    return self.run(*args, **kwds)
  File "/usr/lib/python3.4/unittest/case.py", line 588, in run
    self._feedErrorsToResult(result, outcome.errors)
  File "/usr/lib/python3.4/unittest/case.py", line 518, in _feedErrorsToResult
    result.addError(test, exc_info)
  File "/usr/users/ga002/soranzon/software/nsoranzo_galaxy/.tox/py34-unit/lib/python3.4/site-packages/nose/proxy.py", line 131, in addError
    plugins.addError(self.test, err)
  File "/usr/users/ga002/soranzon/software/nsoranzo_galaxy/.tox/py34-unit/lib/python3.4/site-packages/nose/plugins/manager.py", line 99, in __call__
    return self.call(*arg, **kw)
  File "/usr/users/ga002/soranzon/software/nsoranzo_galaxy/.tox/py34-unit/lib/python3.4/site-packages/nose/plugins/manager.py", line 167, in simple
    result = meth(*arg, **kw)
  File "/usr/users/ga002/soranzon/software/nsoranzo_galaxy/.tox/py34-unit/lib/python3.4/site-packages/nosehtml/plugin.py", line 119, in addError
    self.print_test('error', test, '\n'.join(traceback.format_exception(*error)))
  File "/usr/lib/python3.4/traceback.py", line 181, in format_exception
    return list(_format_exception_iter(etype, value, tb, limit, chain))
  File "/usr/lib/python3.4/traceback.py", line 146, in _format_exception_iter
    for value, tb in values:
  File "/usr/lib/python3.4/traceback.py", line 125, in _iter_chain
    context = exc.__context__
AttributeError: 'str' object has no attribute '__context__'
```

xref. https://github.com/galaxyproject/galaxy/issues/1715