### PR TITLE
Use html.escape instead of cgi.escape

### DIFF
--- a/nosehtml/plugin.py
+++ b/nosehtml/plugin.py
@@ -9,7 +9,7 @@ try:
     from html import escape
 except ImportError:
     # fallback for python 2
-    from cgi import escaoe
+    from cgi import escape
 
 from nose.plugins.base import Plugin
 

--- a/nosehtml/plugin.py
+++ b/nosehtml/plugin.py
@@ -1,11 +1,15 @@
 from __future__ import print_function
 
-import cgi
 import errno
 import io
 import os
 import sys
 import traceback
+try:
+    from html import escape
+except ImportError:
+    # fallback for python 2
+    from cgi import escaoe
 
 from nose.plugins.base import Plugin
 
@@ -80,13 +84,13 @@ class NoseHTML(Plugin):
                 print(u"<div><span class='label'>Status:</span> %s</div>" % unicodify(status), file=f.file)
             if test.capturedOutput:
                 print(u"<div><span class='label'>Output:</span> <a href=\"javascript:toggle('capture_%d')\">...</a></div>" % f.counter, file=f.file)
-                print(u"<div id='capture_%d' style='display: none'><pre class='capture'>%s</pre></div>" % (f.counter, unicodify(cgi.escape(test.capturedOutput))), file=f.file)
+                print(u"<div id='capture_%d' style='display: none'><pre class='capture'>%s</pre></div>" % (f.counter, unicodify(escape(test.capturedOutput))), file=f.file)
             if hasattr(test, 'capturedLogging') and test.capturedLogging:
                 print(u"<div><span class='label'>Log:</span> <a href=\"javascript:toggle('log_%d')\">...</a></div>" % f.counter, file=f.file)
-                print(u"<div id='log_%d' style='display: none'><pre class='log'>%s</pre></div>" % (f.counter, unicodify(cgi.escape("\n".join(test.capturedLogging)))), file=f.file)
+                print(u"<div id='log_%d' style='display: none'><pre class='log'>%s</pre></div>" % (f.counter, unicodify(escape("\n".join(test.capturedLogging)))), file=f.file)
             if error:
                 print(u"<div><span class='label'>Exception:</span> <a href=\"javascript:toggle('exception_%d')\">...</a></div>" % f.counter, file=f.file)
-                print(u"<div id='exception_%d' style='display: none'><pre class='exception'>%s</pre></div>" % (f.counter, unicodify(cgi.escape(error))), file=f.file)
+                print(u"<div id='exception_%d' style='display: none'><pre class='exception'>%s</pre></div>" % (f.counter, unicodify(escape(error))), file=f.file)
             print(u"</div>", file=f.file)
             f.file.flush()
 

--- a/nosehtml/plugin.py
+++ b/nosehtml/plugin.py
@@ -84,13 +84,13 @@ class NoseHTML(Plugin):
                 print(u"<div><span class='label'>Status:</span> %s</div>" % unicodify(status), file=f.file)
             if test.capturedOutput:
                 print(u"<div><span class='label'>Output:</span> <a href=\"javascript:toggle('capture_%d')\">...</a></div>" % f.counter, file=f.file)
-                print(u"<div id='capture_%d' style='display: none'><pre class='capture'>%s</pre></div>" % (f.counter, unicodify(escape(test.capturedOutput))), file=f.file)
+                print(u"<div id='capture_%d' style='display: none'><pre class='capture'>%s</pre></div>" % (f.counter, unicodify(escape(test.capturedOutput, quote=True))), file=f.file)
             if hasattr(test, 'capturedLogging') and test.capturedLogging:
                 print(u"<div><span class='label'>Log:</span> <a href=\"javascript:toggle('log_%d')\">...</a></div>" % f.counter, file=f.file)
-                print(u"<div id='log_%d' style='display: none'><pre class='log'>%s</pre></div>" % (f.counter, unicodify(escape("\n".join(test.capturedLogging)))), file=f.file)
+                print(u"<div id='log_%d' style='display: none'><pre class='log'>%s</pre></div>" % (f.counter, unicodify(escape("\n".join(test.capturedLogging), quote=True))), file=f.file)
             if error:
                 print(u"<div><span class='label'>Exception:</span> <a href=\"javascript:toggle('exception_%d')\">...</a></div>" % f.counter, file=f.file)
-                print(u"<div id='exception_%d' style='display: none'><pre class='exception'>%s</pre></div>" % (f.counter, unicodify(escape(error))), file=f.file)
+                print(u"<div id='exception_%d' style='display: none'><pre class='exception'>%s</pre></div>" % (f.counter, unicodify(escape(error, quote=True))), file=f.file)
             print(u"</div>", file=f.file)
             f.file.flush()
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="NoseHTML",
-    version="0.4.5",
+    version="0.4.6",
     description="""HTML Output plugin for Nose / Nosetests""",
     url='https://github.com/galaxyproject/nosehtml',
     author='James Taylor, Nate Coraor, Dave Bouvier',

--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,10 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Software Development :: Testing",
     ]
 )


### PR DESCRIPTION
`cgi.escape` has been removed in Python 3.8.